### PR TITLE
[fix] 서적 전체 조회 Response Data 수정

### DIFF
--- a/src/modules/book/book.controller.ts
+++ b/src/modules/book/book.controller.ts
@@ -38,19 +38,26 @@ export class BookController {
   ): Promise<void> {
     try {
       const userId = req.session.userId;
-      const newBook = await this.bookService.createBook(createBookDto, images, userId);
+      const newBook = await this.bookService.createBook(
+        createBookDto,
+        images,
+        userId,
+      );
       const response = this.bookMapper.EntityToDto(newBook);
       res.status(HttpStatus.CREATED).json(response);
     } catch (error) {
-      res.status(HttpStatus.INTERNAL_SERVER_ERROR).json({ error: error.message });
+      res
+        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+        .json({ error: error.message });
     }
   }
 
-
-
   @Get()
-  async getAllBooks(@Res() res: Response) {
-    const books = await this.bookService.getAllBooks();
+  async getAllBooks(@Query('pageNum') pageNum: number, @Res() res: Response) {
+    pageNum = Number(pageNum);
+    const pageSize = 8;
+
+    const books = await this.bookService.getAllBooks(pageNum, pageSize);
     res.status(HttpStatus.OK).json(books);
   }
 
@@ -72,10 +79,7 @@ export class BookController {
     @Query('type') type: string,
     @Res() res: Response,
   ) {
-    const filteredBooks = await this.bookService.filterBooks(
-      grade,
-      type,
-    );
+    const filteredBooks = await this.bookService.filterBooks(grade, type);
     res.status(HttpStatus.OK).json(filteredBooks);
   }
 
@@ -94,7 +98,7 @@ export class BookController {
         id,
         updateBookDto,
         userId,
-        images
+        images,
       );
       res.status(HttpStatus.OK).json(updatedBook);
     } catch (error) {

--- a/src/modules/book/dto/paginated-book-response.dto.ts
+++ b/src/modules/book/dto/paginated-book-response.dto.ts
@@ -1,0 +1,8 @@
+import { BookOverViewDto } from './book-overview.dto';
+
+export interface PaginatedBooksResponse {
+  data: BookOverViewDto[];
+  pageNum: number;
+  pageSize: number;
+  total: number;
+}


### PR DESCRIPTION
## 🛠️ 변경사항
- 페이지네이션 구현에 필요한 pageNum, pageSize 데이터를 Response에 추가했습니다.
</br>

## 🚨 유의사항
- 페이지번호는 쿼리 파라미터로 요청, 페이지사이즈는 8개로 고정하도록 구현했습니다.
</br>

## 🔎 참고자료

</br>

## ✅ 체크리스트
- [x] 하나의 메소드는 최소의 기능만 하도록 설정했나요?
- [x] 수정 가능하도록 유연하게 작성했나요?
- [x] 필요 없는 import문이나 setter 등을 삭제했나요?
- [x] 기존의 코드에 영향이 없는 것을 확인하였나요?
